### PR TITLE
Deprecate core

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ shell.on('gl-init', function() {
     varying vec2 uv;\
     void main() {\
       gl_FragColor = vec4(0.5*(uv+1.0), 0.5*(cos(t)+1.0), 1.0);\
-    }'')
+    }')
 
   //Create vertex buffer
   buffer = gl.createBuffer()
@@ -106,7 +106,7 @@ Constructs a shader object from the output of `glslify`.
 #### `shader.bind()`
 Binds the shader for rendering
 
-#### `shader.update(vertSource, fragSource[, uniforms, attributes])`
+#### `shader.update(vertSource,fragSource[,uniforms,attributes])`
 Rebuilds the shader object with new vertex and fragment shaders (same behavior as constructor)
 
 #### `shader.update(glslifyResult)`
@@ -151,18 +151,31 @@ shader.uniforms.matrix = [ 1, 0, 1, 0,
                            0, 0, 0, 1 ]
 ```
 
-You can also read the value of uniform too if the underlying shader is currently bound.  For example,
+You can read the value of uniform too if the underlying shader is currently bound.  For example,
 
 ```javascript
+shader.bind()
 console.log(shader.uniforms.scalar)
 console.log(shader.uniforms.vector)
 console.log(shader.uniforms.matrix)
 ```
 
-Struct uniforms can also be accessed using the normal dot property syntax.  For example,
+Struct uniforms can also be accessed using the normal dot property syntax:
 
 ```javascript
 shader.uniforms.light[0].color = [1, 0, 0, 1]
+```
+
+It is also possible to initialize uniforms in bulk by assigning an object:
+
+```javascript
+shader.uniforms = {
+  model:  [1, 0, 0, 0,
+           0, 1, 0, 0,
+           0, 0, 1, 0,
+           0, 0, 0, 1],
+  color:  [1, 0, 1, 1]
+}
 ```
 
 ### Attributes
@@ -178,7 +191,7 @@ shader.attributes.color = [1, 0, 0, 1]
 
 This internally uses [`gl.vertexAttribnf`](http://www.khronos.org/opengles/sdk/docs/man/xhtml/glVertexAttrib.xml). Setting the attribute will also call `gl.disableVertexAttribArray` on the attribute's location.
 
-### `attrib.location`
+#### `attrib.location`
 This property accesses the location of the attribute.  You can assign/read from it to modify the location of the attribute.  For example, you can update the location by doing:
 
 ```javascript
@@ -193,7 +206,7 @@ console.log(attrib.location)
 
 **WARNING** Changing the attribute location requires recompiling the program. This recompilation is deferred until the next call to `.bind()`
 
-### `attrib.pointer([type, normalized, stride, offset])`
+#### `attrib.pointer([type, normalized, stride, offset])`
 A shortcut for `gl.vertexAttribPointer`/`gl.enableVertexAttribArray`.  See the [OpenGL man page for details on how this works](http://www.khronos.org/opengles/sdk/docs/man/xhtml/glVertexAttribPointer.xml).  The main difference here is that the WebGL context, size and index are known and so these parameters are bound.
 
 * `type` is the type of the pointer (default `gl.FLOAT`)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 gl-shader
 =========
-Simple wrapper for WebGL shaders
+A wrapper for WebGL shaders.  Part of [stack.gl](http://stack.gl)
 
 # Example
 
@@ -177,6 +177,8 @@ shader.uniforms = {
   color:  [1, 0, 1, 1]
 }
 ```
+
+The contents of uniform values are lost when a shader is unbound.
 
 ### Attributes
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A wrapper for WebGL shaders.  Part of [stack.gl](http://stack.gl)
 
 # Example
 
-Try it out now in your browser:  [http://mikolalysenko.github.io/gl-shader/](http://mikolalysenko.github.io/gl-shader/)
+Try it out now in your browser:  [http://stackgl.github.io/gl-shader/](http://stackgl.github.io/gl-shader/)
 
 ```javascript
 var shell = require('gl-now')()
@@ -59,7 +59,7 @@ shell.on('gl-render', function(t) {
 
 Here is the result:
 
-<img src="https://raw.github.com/mikolalysenko/gl-shader/master/screenshot.png">
+<img src="https://raw.github.com/stackgl/gl-shader/master/screenshot.png">
 
 # Install
 

--- a/README.md
+++ b/README.md
@@ -216,6 +216,43 @@ A shortcut for `gl.vertexAttribPointer`/`gl.enableVertexAttribArray`.  See the [
 * `stride` the byte offset between consecutive generic vertex attributes.  (Default: `0`)
 * `offset` offset of the first element of the array in bytes. (Default `0`)
 
+#### Matrix attributes
+
+Matrix attributes are also supported, however there are a few subtle difference.  Due to WebGL limitations, d-dimensional matrix attributes require d separate attribute locations.  If `matrix` is a matrix attribute, then the rows of the matrix can be accessed independently using:
+
+```javascript
+//First row of matrix
+shader.attributes.matrix[0]
+
+//Second row
+shader.attributes.matrix[1]
+
+// ... etc.
+```
+
+The interface for these attributes is identical to the above interfaces for vector attributes (support constant setters, `.pointer()`, and `.location`).
+
+There is also a bulk interface which simplifies working with the matrix as a whole unit.  For example, it is possible to update the location of each row of the matrix simultaneously by assigning it a vector value:
+
+```javascript
+shader.attributes.matrix.location = [1, 2, 3, 4]
+```
+
+Similarly, if the matrix attribute is stored as a contiguous range in memory, the pointer for each row can be set using `.pointer()`.  For example, if `matrix` is a 4x4 matrix attribute then,
+
+```javascript
+shader.attributes.matrix.pointer(gl.FLOAT, false, 16, 0)
+```
+
+is equivalent to,
+
+```javascript
+shader.attributes.matrix[0].pointer(gl.FLOAT, false, 16, 0)
+shader.attributes.matrix[0].pointer(gl.FLOAT, false, 16, 4)
+shader.attributes.matrix[0].pointer(gl.FLOAT, false, 16, 8)
+shader.attributes.matrix[0].pointer(gl.FLOAT, false, 16, 12)
+```
+
 ### Reflection
 
 Finally, the library supports some reflection capabilities.  The set of all uniforms and data types are stored in the "type" property of the shader object,

--- a/example/example.js
+++ b/example/example.js
@@ -10,10 +10,10 @@ shell.on("gl-init", function() {
   shader = makeShader(gl,
     "attribute vec3 position;\
     attribute vec3 color;\
+    uniform mat4 matrix;\
     varying vec3 fcolor;\
-    uniform mat4 mvp;\
     void main() {\
-      gl_Position = mvp * vec4(position, 1.0);\
+      gl_Position = matrix * vec4(position, 1.0);\
       fcolor = color;\
     }",
     "precision highp float;\
@@ -22,6 +22,9 @@ shell.on("gl-init", function() {
     void main() {\
       gl_FragColor = vec4(fcolor + tp, 1.0);\
     }")
+
+  shader.attributes.position.location = 0
+  shader.attributes.color.location = 1
 
   //Create vertex buffer
   buffer = gl.createBuffer()
@@ -46,11 +49,11 @@ shell.on("gl-render", function(t) {
 
   //Set uniforms
   shader.uniforms.tp = [Math.cos(0.001 * Date.now()), 1, 0]
-  shader.uniforms.mvp = [1, 0, 0, 0, 
+  shader.uniforms.matrix = [1, 0, 0, 0, 
                          0, 1, 0, 0, 
                          0, 0, 1, 0,
                          0, 0, 0, 1]
-
+  
   //Draw
   gl.drawArrays(gl.TRIANGLES, 0, 3)
 })

--- a/lib/create-attributes.js
+++ b/lib/create-attributes.js
@@ -7,12 +7,14 @@ function ShaderAttribute(
   , wrapper
   , index
   , locations
-  , dimension) {
+  , dimension
+  , constFunc) {
   this._gl        = gl
   this._wrapper   = wrapper
   this._index     = index
   this._locations = locations
   this._dimension = dimension
+  this._constFunc = constFunc
 }
 
 var proto = ShaderAttribute.prototype
@@ -34,8 +36,11 @@ proto.pointer = function setAttribPointer(
     , !!normalized
     , stride || 0
     , offset || 0)
+  gl.enableVertexAttribArray(location)
+}
 
-  this._gl.enableVertexAttribArray(location)
+proto.set = function(x0, x1, x2, x3) {
+  return this._constFunc(this._locations[this._index], x0, x1, x2, x3)
 }
 
 Object.defineProperty(proto, 'location', {
@@ -44,12 +49,12 @@ Object.defineProperty(proto, 'location', {
   }
   , set: function(v) {
     if(v !== this._locations[this._index]) {
-      this._locations[this._index] = v
+      this._locations[this._index] = v|0
       this._wrapper.program = null
     }
+    return v|0
   }
 })
-
 
 //Adds a vector attribute to obj
 function addVectorAttribute(
@@ -68,14 +73,13 @@ function addVectorAttribute(
     constFuncArgs.push('x'+i)
     varNames.push('x'+i)
   }
-  constFuncArgs.push([
-    'if(x0.length===void 0){return gl.vertexAttrib'
-    , dimension, 'f(v,'
-    , varNames.join()
-    , ')}else{return gl.vertexAttrib'
-    , dimension
-    , 'fv(v,x0)}'
-  ].join(''))
+  constFuncArgs.push(
+    'if(x0.length===void 0){return gl.vertexAttrib' +
+    dimension + 'f(v,' +
+    varNames.join() +
+    ')}else{return gl.vertexAttrib' +
+    dimension +
+    'fv(v,x0)}')
   var constFunc = Function.apply(null, constFuncArgs)
 
   //Create attribute wrapper
@@ -84,7 +88,8 @@ function addVectorAttribute(
     , wrapper
     , index
     , locations
-    , dimension)
+    , dimension
+    , constFunc)
 
   //Create accessor
   Object.defineProperty(obj, name, {
@@ -95,6 +100,96 @@ function addVectorAttribute(
     }
     , get: function() {
       return attr
+    }
+    , enumerable: true
+  })
+}
+
+function addMatrixAttribute(
+    gl
+  , wrapper
+  , index
+  , locations
+  , dimension
+  , obj
+  , name) {
+
+  var parts = new Array(dimension)
+  var attrs = new Array(dimension)
+  for(var i=0; i<dimension; ++i) {
+    addVectorAttribute(
+        gl
+      , wrapper
+      , index[i]
+      , locations
+      , dimension
+      , parts
+      , i)
+    attrs[i] = parts[i]
+  }
+
+  Object.defineProperty(parts, 'location', {
+    set: function(v) {
+      if(Array.isArray) {
+        for(var i=0; i<dimension; ++i) {
+          attrs[i].location = v[i]
+        }
+      } else {
+        for(var i=0; i<dimension; ++i) {
+          result[i] = attrs[i].location = v + i
+        }
+      }
+      return v
+    }
+    , get: function() {
+      var result = new Array(dimension)
+      for(var i=0; i<dimension; ++i) {
+        result[i] = locations[index[i]]
+      }
+      return result
+    }
+    , enumerable: true
+  })
+
+  parts.pointer = function(type, normalized, stride, offset) {
+    type       = type || gl.FLOAT
+    normalized = !!normalized
+    stride     = stride || (dimension * dimension)
+    offset     = offset || 0
+    for(var i=0; i<dimension; ++i) {
+      var location = locations[index[i]]
+      gl.vertexAttribPointer(
+            location
+          , dimension
+          , type
+          , normalized
+          , stride
+          , offset + i * dimension)
+      gl.enableVertexAttribArray(location)
+    }
+  }
+
+  var scratch = new Array(dimension)
+  var vertexAttrib = gl['vertexAttrib' + dimension + 'fv']
+
+  Object.defineProperty(obj, name, {
+    set: function(x) {
+      for(var i=0; i<dimension; ++i) {
+        var loc = locations[index[i]]
+        gl.disableVertexAttribArray(loc)
+        if(Array.isArray(x[0])) {
+          vertexAttrib.call(gl, loc, x[i])
+        } else {
+          for(var j=0; j<dimension; ++j) {
+            scratch[j] = x[dimension*i + j]
+          }
+          vertexAttrib.call(gl, loc, scratch)
+        }
+      }
+      return x
+    }
+    , get: function() {
+      return parts
     }
     , enumerable: true
   })
@@ -113,7 +208,8 @@ function createAttributeWrapper(
     var a = attributes[i]
     var name = a.name
     var type = a.type
-    
+    var locs = a.locations
+
     switch(type) {
       case 'bool':
       case 'int':
@@ -121,7 +217,7 @@ function createAttributeWrapper(
         addVectorAttribute(
             gl
           , wrapper
-          , i
+          , locs[0]
           , locations
           , 1
           , obj
@@ -137,7 +233,20 @@ function createAttributeWrapper(
           addVectorAttribute(
               gl
             , wrapper
-            , i
+            , locs[0]
+            , locations
+            , d
+            , obj
+            , name)
+        } else if(type.indexOf('mat') >= 0) {
+          var d = type.charCodeAt(type.length-1) - 48
+          if(d < 2 || d > 4) {
+            throw new Error('gl-shader: Invalid data type for attribute ' + name + ': ' + type)
+          }
+          addMatrixAttribute(
+              gl
+            , wrapper
+            , locs
             , locations
             , d
             , obj

--- a/lib/create-attributes.js
+++ b/lib/create-attributes.js
@@ -1,0 +1,152 @@
+'use strict'
+
+module.exports = createAttributeWrapper
+
+function ShaderAttribute(
+    gl
+  , wrapper
+  , index
+  , locations
+  , dimension) {
+  this._gl        = gl
+  this._wrapper   = wrapper
+  this._index     = index
+  this._locations = locations
+  this._dimension = dimension
+}
+
+var proto = ShaderAttribute.prototype
+
+proto.pointer = function setAttribPointer(
+    type
+  , normalized
+  , stride
+  , offset) {
+
+  var self      = this
+  var gl        = self._gl
+  var location  = self._locations[self._index]
+
+  gl.vertexAttribPointer(
+      location
+    , self._dimension
+    , type || gl.FLOAT
+    , !!normalized
+    , stride || 0
+    , offset || 0)
+
+  this._gl.enableVertexAttribArray(location)
+}
+
+Object.defineProperty(proto, 'location', {
+  get: function() {
+    return this._locations[this._index]
+  }
+  , set: function(v) {
+    if(v !== this._locations[this._index]) {
+      this._locations[this._index] = v
+      this._wrapper.program = null
+    }
+  }
+})
+
+
+//Adds a vector attribute to obj
+function addVectorAttribute(
+    gl
+  , wrapper
+  , index
+  , locations
+  , dimension
+  , obj
+  , name) {
+
+  //Construct constant function
+  var constFuncArgs = [ 'gl', 'v' ]
+  var varNames = []
+  for(var i=0; i<dimension; ++i) {
+    constFuncArgs.push('x'+i)
+    varNames.push('x'+i)
+  }
+  constFuncArgs.push([
+    'if(x0.length===void 0){return gl.vertexAttrib'
+    , dimension, 'f(v,'
+    , varNames.join()
+    , ')}else{return gl.vertexAttrib'
+    , dimension
+    , 'fv(v,x0)}'
+  ].join(''))
+  var constFunc = Function.apply(null, constFuncArgs)
+
+  //Create attribute wrapper
+  var attr = new ShaderAttribute(
+      gl
+    , wrapper
+    , index
+    , locations
+    , dimension)
+
+  //Create accessor
+  Object.defineProperty(obj, name, {
+    set: function(x) {
+      gl.disableVertexAttribArray(locations[index])
+      constFunc(gl, locations[index], x)
+      return x
+    }
+    , get: function() {
+      return attr
+    }
+    , enumerable: true
+  })
+}
+
+//Create shims for attributes
+function createAttributeWrapper(
+    gl
+  , wrapper
+  , attributes
+  , locations) {
+
+  var obj = {}
+  for(var i=0, n=attributes.length; i<n; ++i) {
+
+    var a = attributes[i]
+    var name = a.name
+    var type = a.type
+    
+    switch(type) {
+      case 'bool':
+      case 'int':
+      case 'float':
+        addVectorAttribute(
+            gl
+          , wrapper
+          , i
+          , locations
+          , 1
+          , obj
+          , name)
+      break
+      
+      default:
+        if(type.indexOf('vec') >= 0) {
+          var d = type.charCodeAt(type.length-1) - 48
+          if(d < 2 || d > 4) {
+            throw new Error('gl-shader: Invalid data type for attribute ' + name + ': ' + type)
+          }
+          addVectorAttribute(
+              gl
+            , wrapper
+            , i
+            , locations
+            , d
+            , obj
+            , name)
+        } else {
+          throw new Error('gl-shader: Unknown data type for attribute ' + name + ': ' + type)
+        }
+      break
+    }
+  }
+  return obj
+}

--- a/lib/create-uniforms.js
+++ b/lib/create-uniforms.js
@@ -1,0 +1,183 @@
+'use strict'
+
+var dup = require('dup')
+var coallesceUniforms = require('./reflect')
+
+module.exports = createUniformWrapper
+
+//Binds a function and returns a value
+function identity(x) {
+  var c = new Function('y', 'return function(){return y}')
+  return c(x)
+}
+
+//Create shims for uniforms
+function createUniformWrapper(gl, wrapper, uniforms, locations) {
+
+  function makeGetter(index) {
+    var proc = new Function(
+        'gl'
+      , 'wrapper'
+      , 'locations'
+      , 'return function(){return gl.getUniform(wrapper.program,locations[' + index + '])}') 
+    return proc(gl, wrapper, locations)
+  }
+
+  function makePropSetter(path, index, type) {
+    switch(type) {
+      case 'bool':
+      case 'int':
+      case 'sampler2D':
+      case 'samplerCube':
+        return 'gl.uniform1i(locations[' + index + '],obj' + path + ')'
+      case 'float':
+        return 'gl.uniform1f(locations[' + index + '],obj' + path + ')'
+      default:
+        var vidx = type.indexOf('vec')
+        if(0 <= vidx && vidx <= 1 && type.length === 4 + vidx) {
+          var d = type.charCodeAt(type.length-1) - 48
+          if(d < 2 || d > 4) {
+            throw new Error('gl-shader: Invalid data type')
+          }
+          switch(type.charAt(0)) {
+            case 'b':
+            case 'i':
+              return 'gl.uniform' + d + 'iv(locations[' + index + '],obj' + path + ')'
+            case 'v':
+              return 'gl.uniform' + d + 'fv(locations[' + index + '],obj' + path + ')'
+            default:
+              throw new Error('gl-shader: Unrecognized data type for vector ' + name + ': ' + type)
+          }
+        } else if(type.indexOf('mat') === 0 && type.length === 4) {
+          var d = type.charCodeAt(type.length-1) - 48
+          if(d < 2 || d > 4) {
+            throw new Error('gl-shader: Invalid uniform dimension type for matrix ' + name + ': ' + type)
+          }
+          return 'gl.uniformMatrix' + d + 'fv(locations[' + index + '],false,obj' + path + ')'
+        } else {
+          throw new Error('gl-shader: Unknown uniform data type for ' + name + ': ' + type)
+        }
+      break
+    }
+  }
+
+  function enumerateIndices(prefix, type) {
+    if(typeof type !== 'object') {
+      return [ [prefix, type] ]
+    }
+    var indices = []
+    for(var id in type) {
+      var prop = type[id]
+      var tprefix = prefix
+      if(parseInt(id) + '' === id) {
+        tprefix += '[' + id + ']'
+      } else {
+        tprefix += '.' + id
+      }
+      if(typeof prop === 'object') {
+        indices.push.apply(indices, enumerateIndices(tprefix, prop))
+      } else {
+        indices.push([tprefix, prop])
+      }
+    }
+    return indices
+  }
+
+  function makeSetter(type) {
+    var code = [ 'return function updateProperty(obj){' ]
+    var indices = enumerateIndices('', type)
+    for(var i=0; i<indices.length; ++i) {
+      var item = indices[i]
+      var path = item[0]
+      var idx  = item[1]
+      if(locations[idx]) {
+        code.push(makePropSetter(path, idx, uniforms[idx].type))
+      }
+    }
+    code.push('return obj}')
+    var proc = new Function('gl', 'locations', code.join('\n'))
+    return proc(gl, locations)
+  }
+
+  function defaultValue(type) {
+    switch(type) {
+      case 'bool':
+        return false
+      case 'int':
+      case 'sampler2D':
+      case 'samplerCube':
+        return 0
+      case 'float':
+        return 0.0
+      default:
+        var vidx = type.indexOf('vec')
+        if(0 <= vidx && vidx <= 1 && type.length === 4 + vidx) {
+          var d = type.charCodeAt(type.length-1) - 48
+          if(d < 2 || d > 4) {
+            throw new Error('gl-shader: Invalid data type')
+          }
+          if(type.charAt(0) === 'b') {
+            return dup(d, false)
+          }
+          return dup(d)
+        } else if(type.indexOf('mat') === 0 && type.length === 4) {
+          var d = type.charCodeAt(type.length-1) - 48
+          if(d < 2 || d > 4) {
+            throw new Error('gl-shader: Invalid uniform dimension type for matrix ' + name + ': ' + type)
+          }
+          return dup(d*d)
+        } else {
+          throw new Error('gl-shader: Unknown uniform data type for ' + name + ': ' + type)
+        }
+      break
+    }
+  }
+
+  function storeProperty(obj, prop, type) {
+    if(typeof type === 'object') {
+      var child = processObject(type)
+      Object.defineProperty(obj, prop, {
+        get: identity(child),
+        set: makeSetter(type),
+        enumerable: true,
+        configurable: false
+      })
+    } else {
+      if(locations[type]) {
+        Object.defineProperty(obj, prop, {
+          get: makeGetter(type),
+          set: makeSetter(type),
+          enumerable: true,
+          configurable: false
+        })
+      } else {
+        obj[prop] = defaultValue(uniforms[type].type)
+      }
+    }
+  }
+
+  function processObject(obj) {
+    var result
+    if(Array.isArray(obj)) {
+      result = new Array(obj.length)
+      for(var i=0; i<obj.length; ++i) {
+        storeProperty(result, i, obj[i])
+      }
+    } else {
+      result = {}
+      for(var id in obj) {
+        storeProperty(result, id, obj[id])
+      }
+    }
+    return result
+  }
+
+  //Return data
+  var coallesced = coallesceUniforms(uniforms, true)
+  return {
+    get: identity(processObject(coallesced)),
+    set: makeSetter(coallesced),
+    enumerable: true,
+    configurable: true
+  }
+}

--- a/lib/reflect.js
+++ b/lib/reflect.js
@@ -1,0 +1,57 @@
+'use strict'
+
+module.exports = makeReflectTypes
+
+//Construct type info for reflection.
+//
+// This iterates over the flattened list of uniform type values and smashes them into a JSON object.
+//
+// The leaves of the resulting object are either indices or type strings representing primitive glslify types
+function makeReflectTypes(uniforms, useIndex) {
+  var obj = {}
+  for(var i=0; i<uniforms.length; ++i) {
+    var n = uniforms[i].name
+    var parts = n.split(".")
+    var o = obj
+    for(var j=0; j<parts.length; ++j) {
+      var x = parts[j].split("[")
+      if(x.length > 1) {
+        if(!(x[0] in o)) {
+          o[x[0]] = []
+        }
+        o = o[x[0]]
+        for(var k=1; k<x.length; ++k) {
+          var y = parseInt(x[k])
+          if(k<x.length-1 || j<parts.length-1) {
+            if(!(y in o)) {
+              if(k < x.length-1) {
+                o[y] = []
+              } else {
+                o[y] = {}
+              }
+            }
+            o = o[y]
+          } else {
+            if(useIndex) {
+              o[y] = i
+            } else {
+              o[y] = uniforms[i].type
+            }
+          }
+        }
+      } else if(j < parts.length-1) {
+        if(!(x[0] in o)) {
+          o[x[0]] = {}
+        }
+        o = o[x[0]]
+      } else {
+        if(useIndex) {
+          o[x[0]] = i
+        } else {
+          o[x[0]] = uniforms[i].type
+        }
+      }
+    }
+  }
+  return obj
+}

--- a/lib/runtime-reflect.js
+++ b/lib/runtime-reflect.js
@@ -1,0 +1,68 @@
+'use strict'
+
+exports.uniforms    = runtimeUniforms
+exports.attributes  = runtimeAttributes
+
+var GL_TO_GLSL_TYPES = {
+  'FLOAT':       'float',
+  'FLOAT_VEC2':  'vec2',
+  'FLOAT_VEC3':  'vec3',
+  'FLOAT_VEC4':  'vec4',
+  'INT':         'int',
+  'INT_VEC2':    'ivec2',
+  'INT_VEC3':    'ivec3',
+  'INT_VEC4':    'ivec4',
+  'BOOL':        'bool',
+  'BOOL_VEC2':   'bvec2',
+  'BOOL_VEC3':   'bvec3',
+  'BOOL_VEC4':   'bvec4',
+  'FLOAT_MAT2':  'mat2',
+  'FLOAT_MAT3':  'mat3',
+  'FLOAT_MAT4':  'mat4',
+  'SAMPLER_2D':  'sampler2D',
+  'SAMPLER_CUBE':'samplerCube'
+}
+
+var GL_TABLE = null
+
+function getType(gl, type) {
+  if(!GL_TABLE) {
+    var typeNames = Object.keys(GL_TO_GLSL_TYPES)
+    GL_TABLE = {}
+    for(var i=0; i<typeNames.length; ++i) {
+      var tn = typeNames[i]
+      GL_TABLE[gl[tn]] = GL_TO_GLSL_TYPES[tn]
+    }
+  }
+  return GL_TABLE[type]
+}
+
+function runtimeUniforms(gl, program) {
+  var numUniforms = gl.getProgramParameter(program, gl.ACTIVE_UNIFORMS)
+  var result = []
+  for(var i=0; i<numUniforms; ++i) {
+    var info = gl.getActiveUniform(program, i)
+    if(info) {
+      result.push({
+        name: info.name,
+        type: getType(gl, info.type)
+      })
+    }
+  }
+  return result
+}
+
+function runtimeAttributes(gl, program) {
+  var numAttributes = gl.getProgramParameter(program, gl.ACTIVE_ATTRIBUTES)
+  var result = []
+  for(var i=0; i<numAttributes; ++i) {
+    var info = gl.getActiveAttrib(program, i)
+    if(info) {
+      result.push({
+        name: info.name,
+        type: getType(gl, info.type)
+      })
+    }
+  }
+  return result
+}

--- a/lib/shader-cache.js
+++ b/lib/shader-cache.js
@@ -1,0 +1,129 @@
+'use strict'
+
+exports.shader   = getShaderReference
+exports.program  = createProgram
+
+var weakMap = typeof WeakMap === 'undefined' ? require('weakmap-shim') : WeakMap
+var CACHE = new weakMap()
+
+var SHADER_COUNTER = 0
+
+function ShaderReference(id, src, type, shader, programs, count, cache) {
+  this.id       = id
+  this.src      = src
+  this.type     = type
+  this.shader   = shader
+  this.count    = count
+  this.programs = []
+  this.cache    = cache
+}
+
+ShaderReference.prototype.dispose = function() {
+  if(--this.count === 0) {
+    var cache    = this.cache
+    var gl       = cache.gl
+    
+    //Remove program references
+    var programs = this.programs
+    for(var i=0, n=programs.length; i<n; ++i) {
+      var p = cache.programs[programs[i]]
+      if(p) {
+        delete cache.programs[i]
+        gl.deleteProgram(p)
+      }
+    }
+
+    //Remove shader reference
+    gl.deleteShader(this.shader)
+    delete cache.shaders[(this.type === gl.FRAGMENT_SHADER)|0][this.src]
+  }
+}
+
+function ContextCache(gl) {
+  this.gl       = gl
+  this.shaders  = [{}, {}]
+  this.programs = {}
+}
+
+var proto = ContextCache.prototype
+
+function compileShader(gl, type, src) {
+  var shader = gl.createShader(type)
+  gl.shaderSource(shader, src)
+  gl.compileShader(shader)
+  if(!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
+    var errLog = gl.getShaderInfoLog(shader)
+    console.error('gl-shader: Error compiling shader:', errLog)
+    throw new Error('gl-shader: Error compiling shader:' + errLog)
+  }
+  return shader
+}
+
+proto.getShaderReference = function(type, src) {
+  var gl      = this.gl
+  var shaders = this.shaders[(type === gl.FRAGMENT_SHADER)|0]
+  var shader  = shaders[src]
+  if(!shader) {
+    var shaderObj = compileShader(gl, type, src)
+    shader = shaders[src] = new ShaderReference(
+      SHADER_COUNTER++,
+      src,
+      type,
+      shaderObj,
+      [],
+      1,
+      this)
+  } else {
+    shader.count += 1
+  }
+  return shader
+}
+
+function linkProgram(gl, vshader, fshader, attribs, locations) {
+  var program = gl.createProgram()
+  gl.attachShader(program, vshader)
+  gl.attachShader(program, fshader)
+  for(var i=0; i<attribs.length; ++i) {
+    gl.bindAttribLocation(program, locations[i], attribs[i])
+  }
+  gl.linkProgram(program)
+  if(!gl.getProgramParameter(program, gl.LINK_STATUS)) {
+    var errLog = gl.getProgramInfoLog(program)
+    console.error('gl-shader: Error linking program:', errLog)
+    throw new Error('gl-shader: Error linking program:' + errLog)
+  }
+  return program
+}
+
+proto.getProgram = function(vref, fref, attribs, locations) {
+  var token = [vref.id, fref.id, attribs.join(':'), locations.join(':')].join('@')
+  var prog  = this.programs[token]
+  if(!prog) {
+    this.programs[token] = prog = linkProgram(
+      this.gl,
+      vref.shader,
+      fref.shader,
+      attribs,
+      locations)
+    vref.programs.push(token)
+    fref.programs.push(token)
+  }
+  return prog
+}
+
+function getCache(gl) {
+  var ctxCache = CACHE.get(gl)
+  if(!ctxCache) {
+    ctxCache = new ContextCache(gl)
+    CACHE.set(gl, ctxCache)
+  }
+  return ctxCache
+}
+
+function getShaderReference(gl, type, src) {
+  return getCache(gl).getShaderReference(type, src)
+}
+
+function createProgram(gl, vref, fref, attribs, locations) {
+  return getCache(gl).getProgram(vref, fref, attribs, locations)
+}

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/mikolalysenko/gl-shader.git"
+    "url": "git://github.com/stackgl/gl-shader.git"
   },
   "keywords": [
     "webgl",
@@ -37,6 +37,6 @@
   "readmeFilename": "README.md",
   "gitHead": "e28ce1d36277aeb6d109d886e847c7cdc1903cd9",
   "bugs": {
-    "url": "https://github.com/mikolalysenko/gl-shader/issues"
+    "url": "https://github.com/stackgl/gl-shader/issues"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,19 +1,17 @@
 {
   "name": "gl-shader",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "description": "WebGL shader wrapper",
   "main": "index.js",
   "directories": {
     "example": "example"
   },
   "dependencies": {
-    "uniq": "^0.0.2",
-    "gl-shader-core": "^2.0.0",
-    "glsl-extract": "^0.0.2",
-    "through": "~2.3.4"
+    "dup": "^1.0.0",
+    "weakmap-shim": "^1.1.0"
   },
   "devDependencies": {
-    "gl-now": "~0.0.0"
+    "gl-now": "^1.4.0"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",


### PR DESCRIPTION
This merges the functionality from gl-shader-core (after dynamic property loading) into gl-shader.

It also adds support for caching attribute locations and matrix attributes, fixing several problems and streamlining the API.