### PR TITLE
Improve shader compile error clarity.

### DIFF
--- a/lib/shader-cache.js
+++ b/lib/shader-cache.js
@@ -3,6 +3,7 @@
 exports.shader   = getShaderReference
 exports.program  = createProgram
 
+var sprintf = require("sprintf-js").sprintf;
 var weakMap = typeof WeakMap === 'undefined' ? require('weakmap-shim') : WeakMap
 var CACHE = new weakMap()
 
@@ -47,14 +48,41 @@ function ContextCache(gl) {
 
 var proto = ContextCache.prototype
 
+function formatCompileError(errLog, src) {
+    var errorStrings = errLog.split('\n');
+    var errors = {};
+    for (var i = 0; i < errorStrings.length; i++) {
+        var errorString = errorStrings[i];
+        var lineNo = parseInt(errorString.split(':')[2]);
+        errors[lineNo] = errorString;
+    }
+    var lines = src.split('\n');
+    var fmt = "";
+    for (var i = 0; i < lines.length; i++) {
+        var line = lines[i];
+        fmt += sprintf("%4d: %s\n", i+1, line);
+        if (errors[i+1]) {
+            var e = errors[i+1];
+            e = e.substr(e.split(':', 3).join(':').length + 1).trim();
+            fmt += sprintf('^^^^: %s\n', e);
+        }
+    }
+    return fmt;
+}
+
 function compileShader(gl, type, src) {
   var shader = gl.createShader(type)
   gl.shaderSource(shader, src)
   gl.compileShader(shader)
   if(!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
     var errLog = gl.getShaderInfoLog(shader)
-    console.error('gl-shader: Error compiling shader:', errLog)
-    throw new Error('gl-shader: Error compiling shader:' + errLog)
+    console.warn(formatCompileError(errLog, src));
+    var errstr = sprintf('gl-shader: Error compiling %s shader:\n%s',
+        type === gl.FRAGMENT_SHADER ? 'fragment' : 'vertex',
+        errLog
+    );
+    console.error(errstr);
+    throw new Error(errstr)
   }
   return shader
 }

--- a/lib/shader-cache.js
+++ b/lib/shader-cache.js
@@ -55,7 +55,12 @@ function compileShader(gl, type, src) {
   gl.compileShader(shader)
   if(!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
     var errLog = gl.getShaderInfoLog(shader)
-    var fmt = formatCompilerError(errLog, src, type);
+    try {
+        var fmt = formatCompilerError(errLog, src, type);
+    } catch (e){
+        console.warn('Failed to format compiler error: ' + e);
+        throw new Error('gl-shader: Error compiling shader:\n' + errLog)
+    }
     console.warn('gl-shader: ' + fmt.long);
     throw new Error('gl-shader: ' + fmt.short)
   }

--- a/lib/shader-cache.js
+++ b/lib/shader-cache.js
@@ -3,7 +3,8 @@
 exports.shader   = getShaderReference
 exports.program  = createProgram
 
-var sprintf = require("sprintf-js").sprintf;
+var formatCompilerError = require('gl-format-compiler-error');
+
 var weakMap = typeof WeakMap === 'undefined' ? require('weakmap-shim') : WeakMap
 var CACHE = new weakMap()
 
@@ -48,41 +49,15 @@ function ContextCache(gl) {
 
 var proto = ContextCache.prototype
 
-function formatCompileError(errLog, src) {
-    var errorStrings = errLog.split('\n');
-    var errors = {};
-    for (var i = 0; i < errorStrings.length; i++) {
-        var errorString = errorStrings[i];
-        var lineNo = parseInt(errorString.split(':')[2]);
-        errors[lineNo] = errorString;
-    }
-    var lines = src.split('\n');
-    var fmt = "";
-    for (var i = 0; i < lines.length; i++) {
-        var line = lines[i];
-        fmt += sprintf("%4d: %s\n", i+1, line);
-        if (errors[i+1]) {
-            var e = errors[i+1];
-            e = e.substr(e.split(':', 3).join(':').length + 1).trim();
-            fmt += sprintf('^^^^: %s\n', e);
-        }
-    }
-    return fmt;
-}
-
 function compileShader(gl, type, src) {
   var shader = gl.createShader(type)
   gl.shaderSource(shader, src)
   gl.compileShader(shader)
   if(!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
     var errLog = gl.getShaderInfoLog(shader)
-    console.warn(formatCompileError(errLog, src));
-    var errstr = sprintf('gl-shader: Error compiling %s shader:\n%s',
-        type === gl.FRAGMENT_SHADER ? 'fragment' : 'vertex',
-        errLog
-    );
-    console.error(errstr);
-    throw new Error(errstr)
+    var fmt = formatCompilerError(errLog, src, type);
+    console.warn('gl-shader: ' + fmt.long);
+    throw new Error('gl-shader: ' + fmt.short)
   }
   return shader
 }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "example": "example"
   },
   "dependencies": {
+    "sprintf-js": "^1.0.3",
     "weakmap-shim": "^1.1.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "example": "example"
   },
   "dependencies": {
-    "sprintf-js": "^1.0.3",
+    "gl-format-compiler-error": "^1.0.0",
     "weakmap-shim": "^1.1.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "example": "example"
   },
   "dependencies": {
-    "gl-format-compiler-error": "^1.0.0",
+    "gl-format-compiler-error": "^1.0.1",
     "weakmap-shim": "^1.1.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "example": "example"
   },
   "dependencies": {
-    "gl-format-compiler-error": "^1.0.1",
+    "gl-format-compiler-error": "^1.0.2",
     "weakmap-shim": "^1.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Reformats the shader compiler error to indicate whether it's a vertex or fragment shader and includes a listing of the code with errors interleaved, like so:

![](http://i.imgur.com/kkHaLQx.png)

I'm happy to make changes, just let me know. There is one aspect of this I wasn't able to make my mind up about: I wanted to make it clear in which shader source the error was occurring, so I log the entire source to the console and log the error at the bottom of the source so that you don't have to scroll up to exapand the stack trace. For shorter sources, this probably isn't a big deal, but longer sources might be tedious to scroll through to find the offending lines. An alternative might be to only log a few lines around each error to give context, but I worry then that the shader won't be as identifiable. Taking suggestions. :)