### PR TITLE
Make errors programmatically usable – wrapped in an GLError (#12)

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,14 +5,15 @@ var createAttributeWrapper = require('./lib/create-attributes')
 var makeReflect            = require('./lib/reflect')
 var shaderCache            = require('./lib/shader-cache')
 var runtime                = require('./lib/runtime-reflect')
+var GLError                = require("./lib/GLError")
 
 //Shader object
 function Shader(gl) {
   this.gl         = gl
 
   //Default initialize these to null
-  this._vref      = 
-  this._fref      = 
+  this._vref      =
+  this._fref      =
   this._relink    =
   this.vertShader =
   this.fragShader =
@@ -42,9 +43,9 @@ proto.dispose = function() {
   this.types      =
   this.vertShader =
   this.fragShader =
-  this.program    = 
-  this._relink    = 
-  this._fref      = 
+  this.program    =
+  this._relink    =
+  this._fref      =
   this._vref      = null
 }
 
@@ -87,7 +88,7 @@ proto.update = function(
     pfref.dispose()
   }
   wrapper.fragShader = wrapper._fref.shader
-  
+
   //If uniforms/attributes is not specified, use RT reflection
   if(!uniforms || !attributes) {
 
@@ -98,10 +99,9 @@ proto.update = function(
     gl.linkProgram(testProgram)
     if(!gl.getProgramParameter(testProgram, gl.LINK_STATUS)) {
       var errLog = gl.getProgramInfoLog(testProgram)
-      console.error('gl-shader: Error linking program:', errLog)
-      throw new Error('gl-shader: Error linking program:' + errLog)
+      throw new GLError(errLog, 'Error linking program:' + errLog)
     }
-    
+
     //Load data from runtime
     uniforms   = uniforms   || runtime.uniforms(gl, testProgram)
     attributes = attributes || runtime.attributes(gl, testProgram)
@@ -129,7 +129,7 @@ proto.update = function(
         attributeNames.push(attr.name + '[' + j + ']')
         if(typeof attr.location === 'number') {
           attributeLocations.push(attr.location + j)
-        } else if(Array.isArray(attr.location) && 
+        } else if(Array.isArray(attr.location) &&
                   attr.location.length === size &&
                   typeof attr.location[j] === 'number') {
           attributeLocations.push(attr.location[j]|0)

--- a/lib/GLError.js
+++ b/lib/GLError.js
@@ -1,0 +1,12 @@
+function GLError (rawError, shortMessage, longMessage) {
+    this.name = 'GLError'
+    this.shortMessage = shortMessage || ''
+    this.longMessage = longMessage || ''
+    this.rawError = rawError || ''
+    this.message =
+      'gl-shader: ' + (shortMessage || rawError || '') +
+      (longMessage ? '\n'+longMessage : '')
+    this.stack = (new Error()).stack
+}
+GLError.prototype = new Error
+module.exports = GLError

--- a/lib/GLError.js
+++ b/lib/GLError.js
@@ -1,5 +1,4 @@
 function GLError (rawError, shortMessage, longMessage) {
-    this.name = 'GLError'
     this.shortMessage = shortMessage || ''
     this.longMessage = longMessage || ''
     this.rawError = rawError || ''
@@ -9,4 +8,6 @@ function GLError (rawError, shortMessage, longMessage) {
     this.stack = (new Error()).stack
 }
 GLError.prototype = new Error
+GLError.prototype.name = 'GLError'
+GLError.prototype.constructor = GLError
 module.exports = GLError

--- a/lib/create-attributes.js
+++ b/lib/create-attributes.js
@@ -2,6 +2,8 @@
 
 module.exports = createAttributeWrapper
 
+var GLError = require("./GLError")
+
 function ShaderAttribute(
     gl
   , wrapper
@@ -228,7 +230,7 @@ function createAttributeWrapper(
         if(type.indexOf('vec') >= 0) {
           var d = type.charCodeAt(type.length-1) - 48
           if(d < 2 || d > 4) {
-            throw new Error('gl-shader: Invalid data type for attribute ' + name + ': ' + type)
+            throw new GLError('', 'Invalid data type for attribute ' + name + ': ' + type)
           }
           addVectorAttribute(
               gl
@@ -241,7 +243,7 @@ function createAttributeWrapper(
         } else if(type.indexOf('mat') >= 0) {
           var d = type.charCodeAt(type.length-1) - 48
           if(d < 2 || d > 4) {
-            throw new Error('gl-shader: Invalid data type for attribute ' + name + ': ' + type)
+            throw new GLError('', 'Invalid data type for attribute ' + name + ': ' + type)
           }
           addMatrixAttribute(
               gl
@@ -252,7 +254,7 @@ function createAttributeWrapper(
             , obj
             , name)
         } else {
-          throw new Error('gl-shader: Unknown data type for attribute ' + name + ': ' + type)
+          throw new GLError('', 'Unknown data type for attribute ' + name + ': ' + type)
         }
       break
     }

--- a/lib/create-uniforms.js
+++ b/lib/create-uniforms.js
@@ -1,6 +1,7 @@
 'use strict'
 
 var coallesceUniforms = require('./reflect')
+var GLError = require("./GLError")
 
 module.exports = createUniformWrapper
 
@@ -26,7 +27,7 @@ function createUniformWrapper(gl, wrapper, uniforms, locations) {
         'gl'
       , 'wrapper'
       , 'locations'
-      , 'return function(){return gl.getUniform(wrapper.program,locations[' + index + '])}') 
+      , 'return function(){return gl.getUniform(wrapper.program,locations[' + index + '])}')
     return proc(gl, wrapper, locations)
   }
 
@@ -44,7 +45,7 @@ function createUniformWrapper(gl, wrapper, uniforms, locations) {
         if(0 <= vidx && vidx <= 1 && type.length === 4 + vidx) {
           var d = type.charCodeAt(type.length-1) - 48
           if(d < 2 || d > 4) {
-            throw new Error('gl-shader: Invalid data type')
+            throw new GLError('', 'Invalid data type')
           }
           switch(type.charAt(0)) {
             case 'b':
@@ -53,16 +54,16 @@ function createUniformWrapper(gl, wrapper, uniforms, locations) {
             case 'v':
               return 'gl.uniform' + d + 'fv(locations[' + index + '],obj' + path + ')'
             default:
-              throw new Error('gl-shader: Unrecognized data type for vector ' + name + ': ' + type)
+              throw new GLError('', 'Unrecognized data type for vector ' + name + ': ' + type)
           }
         } else if(type.indexOf('mat') === 0 && type.length === 4) {
           var d = type.charCodeAt(type.length-1) - 48
           if(d < 2 || d > 4) {
-            throw new Error('gl-shader: Invalid uniform dimension type for matrix ' + name + ': ' + type)
+            throw new GLError('', 'Invalid uniform dimension type for matrix ' + name + ': ' + type)
           }
           return 'gl.uniformMatrix' + d + 'fv(locations[' + index + '],false,obj' + path + ')'
         } else {
-          throw new Error('gl-shader: Unknown uniform data type for ' + name + ': ' + type)
+          throw new GLError('', 'Unknown uniform data type for ' + name + ': ' + type)
         }
       break
     }
@@ -121,7 +122,7 @@ function createUniformWrapper(gl, wrapper, uniforms, locations) {
         if(0 <= vidx && vidx <= 1 && type.length === 4 + vidx) {
           var d = type.charCodeAt(type.length-1) - 48
           if(d < 2 || d > 4) {
-            throw new Error('gl-shader: Invalid data type')
+            throw new GLError('', 'Invalid data type')
           }
           if(type.charAt(0) === 'b') {
             return makeVector(d, false)
@@ -130,11 +131,11 @@ function createUniformWrapper(gl, wrapper, uniforms, locations) {
         } else if(type.indexOf('mat') === 0 && type.length === 4) {
           var d = type.charCodeAt(type.length-1) - 48
           if(d < 2 || d > 4) {
-            throw new Error('gl-shader: Invalid uniform dimension type for matrix ' + name + ': ' + type)
+            throw new GLError('', 'Invalid uniform dimension type for matrix ' + name + ': ' + type)
           }
           return makeVector(d*d, 0)
         } else {
-          throw new Error('gl-shader: Unknown uniform data type for ' + name + ': ' + type)
+          throw new GLError('', 'Unknown uniform data type for ' + name + ': ' + type)
         }
       break
     }

--- a/lib/shader-cache.js
+++ b/lib/shader-cache.js
@@ -3,6 +3,7 @@
 exports.shader   = getShaderReference
 exports.program  = createProgram
 
+var GLError = require("./GLError")
 var formatCompilerError = require('gl-format-compiler-error');
 
 var weakMap = typeof WeakMap === 'undefined' ? require('weakmap-shim') : WeakMap
@@ -59,10 +60,9 @@ function compileShader(gl, type, src) {
         var fmt = formatCompilerError(errLog, src, type);
     } catch (e){
         console.warn('Failed to format compiler error: ' + e);
-        throw new Error('gl-shader: Error compiling shader:\n' + errLog)
+        throw new GLError(errLog, 'Error compiling shader:\n' + errLog)
     }
-    console.warn('gl-shader: ' + fmt.long);
-    throw new Error('gl-shader: ' + fmt.short)
+    throw new GLError(errLog, fmt.short, fmt.long)
   }
   return shader
 }
@@ -97,8 +97,7 @@ function linkProgram(gl, vshader, fshader, attribs, locations) {
   gl.linkProgram(program)
   if(!gl.getProgramParameter(program, gl.LINK_STATUS)) {
     var errLog = gl.getProgramInfoLog(program)
-    console.error('gl-shader: Error linking program:', errLog)
-    throw new Error('gl-shader: Error linking program:' + errLog)
+    throw new GLError(errLog, 'Error linking program: ' + errLog)
   }
   return program
 }


### PR DESCRIPTION
This PR fixes #12 issue.

all gl-shader errors are wrapped in a "GLError" object that contains on top of a classical Error:
- `shortMessage`
- `longMessage`
- `rawError`
the Error's standard message field is a concatenation of shortMessage and longMessage (to a new line)

Also, console.error or console.warn are no longer side-effects when using gl-shader, that way the lib user have full control over error handling (if user just want to validate a shader works but not display it).
If user don't catch the error, a short and long message will be displayed as before.

<img width="932" alt="screen shot 2016-01-01 at 12 23 48" src="https://cloud.githubusercontent.com/assets/211411/12070675/f8642260-b083-11e5-9794-a939df7e240c.png">


But at least you can just use the `error.rawError` part of it:

<img width="283" alt="screen shot 2016-01-01 at 12 27 25" src="https://cloud.githubusercontent.com/assets/211411/12070676/08e95b1e-b084-11e5-8dda-80d8040cd214.png">
