### PR TITLE
Set the number of enabled vertex attributes upon a shader program switch

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ var GLError                = require("./lib/GLError")
 //Shader object
 function Shader(gl) {
   this.gl         = gl
+  this.gl.lastAttribCount = 0  // fixme where else should we store info, safe but not nice on the gl object
 
   //Default initialize these to null
   this._vref      =
@@ -29,10 +30,38 @@ proto.bind = function() {
   if(!this.program) {
     this._relink()
   }
+
+  // ensuring that we have the right number of enabled vertex attributes
+  var i
+  var newAttribCount = this.gl.getProgramParameter(this.program, this.gl.ACTIVE_ATTRIBUTES) // more robust approach
+  //var newAttribCount = Object.keys(this.attributes).length // avoids the probably immaterial introspection slowdown
+  var oldAttribCount = this.gl.lastAttribCount
+  if(newAttribCount > oldAttribCount) {
+    for(i = oldAttribCount; i < newAttribCount; i++) {
+      this.gl.enableVertexAttribArray(i)
+    }
+  } else if(oldAttribCount > newAttribCount) {
+    for(i = newAttribCount; i < oldAttribCount; i++) {
+      this.gl.disableVertexAttribArray(i)
+    }
+  }
+
+  this.gl.lastAttribCount = newAttribCount
+
   this.gl.useProgram(this.program)
 }
 
 proto.dispose = function() {
+
+  // disabling vertex attributes so new shader starts with zero
+  // and it's also useful if all shaders are disposed but the
+  // gl context is reused for subsequent replotting
+  var oldAttribCount = this.gl.lastAttribCount
+  for (var i = 0; i < oldAttribCount; i++) {
+    this.gl.disableVertexAttribArray(i)
+  }
+  this.gl.lastAttribCount = 0
+
   if(this._fref) {
     this._fref.dispose()
   }
@@ -119,7 +148,8 @@ proto.update = function(
   var attributeUnpacked  = []
   var attributeNames     = []
   var attributeLocations = []
-  for(var i=0; i<attributes.length; ++i) {
+  var i
+  for(i=0; i<attributes.length; ++i) {
     var attr = attributes[i]
     if(attr.type.indexOf('mat') >= 0) {
       var size = attr.type.charAt(attr.type.length-1)|0
@@ -159,7 +189,7 @@ proto.update = function(
 
   //For all unspecified attributes, assign them lexicographically min attribute
   var curLocation = 0
-  for(var i=0; i<attributeLocations.length; ++i) {
+  for(i=0; i<attributeLocations.length; ++i) {
     if(attributeLocations[i] < 0) {
       while(attributeLocations.indexOf(curLocation) >= 0) {
         curLocation += 1


### PR DESCRIPTION
We ran into issues resulting in "glDrawArrays: attempt to render with no buffer attached to enabled attribute 1" and nothing rendered from that point on. Deriving from [the standard](https://www.khronos.org/registry/webgl/specs/1.0/#6.5), the way of avoiding the error seems to be either of:

1. managing which vertex attrib arrays are enabled and disabled
2. keeping vertex attrib arrays enabled but binding a mock or legacy buffer to it

The latter solution feels less robust in that it requires bindings to be left around 'just in case' a next shader program has fewer attributes and might benefit from the leftover binding.

This concept is the former solution. It works out fine with the `plotly` codebase on initial tests. There are two slight drawbacks: binding information to the `gl` object is safe but not pretty; use of introspection in render time. The latter problem is easily solved by flipping the comment line in the `var newAttribCount` lines.

I'd like to get feedback as this issue might have already come up and the resolution might have fallen some different way. As far as I know this approach is fairly common in tools that shuffle shaders in and out.